### PR TITLE
spec: add Transport-Layer Privacy section

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1923,6 +1923,54 @@ responses.
 - The `dwn-payment` header ****SHOULD NOT**** exceed 8 KB. Implementations ****MAY****
   reject requests with excessively large payment headers.
 
+### Transport-Layer Privacy {#transport-privacy}
+
+::: note
+DWN messages carried over HTTPS or WebSocket are protected by TLS, which encrypts
+the wire content from network observers. However, TLS alone does not conceal all
+metadata. The target DWN's service endpoint URL is visible in DNS lookups and TLS
+SNI, the sender's IP address is visible to the server, and request timing and
+sizes are observable by network intermediaries. When record-level encryption is
+used (as defined in the [DWN specification](https://github.com/enboxorg/dwn-spec)),
+the record data is additionally protected at rest — but the transport metadata
+remains exposed.
+
+For deployments that require stronger transport-layer privacy, implementations
+****MAY**** wrap DWN JSON-RPC payloads inside a [DIDComm v2](https://identity.foundation/didcomm-messaging/spec/v2.1/)
+encrypted message envelope before transmission. DIDComm's routing protocol
+enables onion-style multi-hop delivery through mediators, where each intermediary
+sees only the next hop and an opaque encrypted payload — no single party along
+the route learns both the original sender and the final recipient. The DIDComm
+envelope is stripped upon delivery to the target DWN server, and the inner DWN
+message is then processed through the standard authorization and handling pipeline.
+
+This layering is strictly additive: the DIDComm envelope provides ephemeral,
+transit-scoped privacy (protecting the journey), while DWN's own authorization
+model, CID-based signatures, and record-level encryption provide persistent,
+data-scoped security (protecting the destination). The two layers serve
+fundamentally different purposes and ****MUST NOT**** be conflated:
+
+- **DIDComm envelopes are disposable.** They use per-message ECDH key agreement
+  (ECDH-1PU for authenticated encryption, or ECDH-ES for anonymous encryption)
+  to protect a single message in transit. Once delivered, the envelope is
+  discarded. DIDComm signatures (when used) wrap the full message body, making
+  them unsuitable for content-addressed storage where data and metadata are
+  stored and verified independently.
+
+- **DWN authorization is persistent.** DWN messages sign a CID of the descriptor
+  — a content-addressed commitment that remains verifiable regardless of how the
+  message was transported or re-serialized. DWN's multi-layered authorization
+  (owner, delegate, permission grant, protocol rules) and hierarchical key
+  derivation for encryption are designed for long-lived data, not ephemeral
+  communication.
+
+Implementations that adopt DIDComm as a transport envelope ****MUST**** ensure that
+DWN message authentication and authorization are performed on the unwrapped DWN
+message, not on any properties of the DIDComm envelope. The DIDComm layer
+provides no authorization guarantees that are meaningful to the DWN processing
+pipeline.
+:::
+
 ## Normative References
 
 [[spec]]


### PR DESCRIPTION
## Summary

- Adds a new `### Transport-Layer Privacy` subsection to `## Security Considerations`
- Documents DIDComm v2 encrypted messages as an optional privacy-preserving transport envelope for DWN JSON-RPC payloads
- Explains why the layering is strictly additive and the two security layers must not be conflated

## Context

DWN messages over HTTPS/WSS are protected by TLS, but TLS alone does not conceal all metadata — the target endpoint is visible in DNS/SNI, the sender's IP is visible to the server, and timing/sizes are observable. For privacy-sensitive deployments, wrapping DWN messages in DIDComm v2 encrypted envelopes enables onion-style multi-hop delivery through mediators where no single intermediary learns both sender and recipient.

The section clarifies that:
- **DIDComm envelopes are disposable** — per-message ECDH, full-body signatures, designed for ephemeral transit
- **DWN authorization is persistent** — CID-based signatures, multi-layered auth (owner/delegate/grant/protocol), HD key derivation, designed for long-lived data

Implementations that adopt DIDComm as transport MUST perform DWN auth on the unwrapped message, not on DIDComm envelope properties.

The section is wrapped in a `:::note` block (non-normative), consistent with the `Future Work: Algorithm Negotiation` note in the DWN spec.