### PR TITLE
feat: service endpoint map format, multi-endpoint resolution, and dataRetention for relay nodes

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1016,7 +1016,6 @@ payment without registration, or neither.
 | `providerAuth.tokenUrl` | `string` | Yes | URL where the client exchanges an authorization code for a registration token. |
 | `providerAuth.refreshUrl` | `string` | No | URL to refresh an expired registration token. If absent, tokens do not support refresh. |
 | `providerAuth.managementUrl` | `string` | No | URL for user-facing account management. If absent, no management UI is available. |
-| `dataRetention` | `string` | No | `"full"` (default if absent) or `"cache"`. Indicates whether the server retains all record data or operates as a best-effort relay/cache. Corresponds to the `dataRetention` property in the DWN service endpoint entry. |
 | `payment` | `object` | No | Payment capabilities. ****MUST**** be present when the server supports [Per-Message Payment](#per-message-payment). |
 | `payment.methods` | `string[]` | Yes | Payment flow methods supported. See [Payment Methods](#payment-methods). |
 | `payment.schemes` | `string[]` | Yes | [[ref:Payment Scheme]] URN identifiers supported. See [Payment Scheme Registry](#payment-scheme-registry). |


### PR DESCRIPTION
## Summary

- Add map format for `serviceEndpoint` entries with `url` and optional `dataRetention` properties, enabling DID documents to distinguish full nodes from relay/cache nodes
- Add multi-endpoint resolution guidance (full vs cache endpoint selection for reads vs writes)
- **Remove** `dataRetention` from the ServerInfo object — it belongs at the per-endpoint level in DID document service entries, not as a server-wide property (a single server may host tenants with different retention semantics)

## Changes

1. **Service endpoint entry format** — entries can be bare strings (implicitly full) or maps with `url` + optional `dataRetention: "cache"`
2. **Endpoint Entry Properties** table and normative prose
3. **Multi-Endpoint Resolution** section with full/cache guidance
4. **ServerInfo cleanup** — removed the `dataRetention` row from the ServerInfo Object table